### PR TITLE
Switch to user dictionary editing when the end of a list of candidates has been reached.

### DIFF
--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -636,7 +636,8 @@ bool SkkState::handleCandidate(KeyEvent &keyEvent) {
         skk_candidate_list_cursor_up(skkCandidates);
         keyEvent.filterAndAccept();
     } else if (keyEvent.key().checkKeyList(*config.cursorDownKey)) {
-        skk_candidate_list_cursor_down(skkCandidates);
+        if (!skk_candidate_list_cursor_down(skkCandidates))
+          return false;
         keyEvent.filterAndAccept();
     } else if (keyEvent.key().checkKeyList(*config.prevPageKey)) {
         skk_candidate_list_page_up(skkCandidates);


### PR DESCRIPTION
Currently, it switches to dictionary editing only when there are zero candidates, but it should also switch when the last candidate is reached.