### PR TITLE
Update input panel on preedit clearing

### DIFF
--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -749,6 +749,10 @@ void SkkState::updateUI() {
         inputPanel.reset();
         ic_->updatePreedit();
         engine_->instance()->showInputMethodInformation(ic_);
+        if (!lastIsEmpty) {
+            // Preedit was cleared.
+            ic_->updateUserInterface(UserInterfaceComponent::InputPanel);
+        }
         return;
     }
 


### PR DESCRIPTION
In some cases, input panel does not disappear even when it should.
To reproduce:

1. Switch to Hiragana mode
2. Put something to preedit.
    + For example, type `k` `y` to put `ky` to preedit.
3. Switch to another mode.
    + For example, type `l` (`set-input-mode-latin` command in hiragana mode) to switch to Latin mode.
4. Now you see the floating window (with `ky` for example) even though the current input mode is Latin.
    + Even worse, this does not disappear until you fill preedit with another content or change the window focus.

The patch solves this issue by updating input panel (floating window) when the input mode is changed and the preedit is cleared.