### PR TITLE
fix SkkEngine::loadDictionary() envvar behavior

### DIFF
--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -534,13 +534,20 @@ void SkkEngine::loadDictionary() {
             if (path.empty() || mode == 0) {
                 continue;
             }
+
+            std::string_view partialpath = path;
+            if (stringutils::consumePrefix(partialpath,
+                                           "$FCITX_CONFIG_DIR/")) {
+                path = StandardPaths::global().userDirectory(
+                           StandardPathsType::PkgData) /
+                       partialpath;
+            } else if (stringutils::consumePrefix(partialpath,
+                                           "$XDG_DATA_DIRS/")) {
+                path = StandardPaths::global().locate(
+                    StandardPathsType::Data, partialpath);
+            }
+
             if (mode == 1) {
-                std::string_view partialpath = path;
-                if (stringutils::consumePrefix(partialpath,
-                                               "$XDG_DATA_DIRS/")) {
-                    path = StandardPaths::global().locate(
-                        StandardPathsType::Data, partialpath);
-                }
                 if (stringutils::endsWith(path, ".cdb")) {
                     SkkCdbDict *dict =
                         skk_cdb_dict_new(path.data(), encoding.data(), nullptr);
@@ -557,13 +564,6 @@ void SkkEngine::loadDictionary() {
                     }
                 }
             } else {
-                std::string_view partialpath = path;
-                if (stringutils::consumePrefix(partialpath,
-                                               "$FCITX_CONFIG_DIR/")) {
-                    path = StandardPaths::global().userDirectory(
-                               StandardPathsType::PkgData) /
-                           partialpath;
-                }
                 SkkUserDict *userdict =
                     skk_user_dict_new(path.data(), encoding.data(), nullptr);
                 if (userdict) {


### PR DESCRIPTION
This behavior, present since fcitx-4, is weird.
Several Japanese users seem to have thought so too.
I recently noticed this, so I filed this PR.

cf.
- https://github.com/fcitx/fcitx-skk/pull/7
- https://mastodon.cardina1.red/@lo48576/111116778807095282
- https://appsweets.net/blog/2020/01/18/skk-is-2/