### PR TITLE
Refactor: Replace QDialog::exec() with QDialog::open()

### DIFF
--- a/gui/dictwidget.cpp
+++ b/gui/dictwidget.cpp
@@ -65,12 +65,15 @@ void SkkDictWidget::save() {
 }
 
 void SkkDictWidget::addDictClicked() {
-    AddDictDialog dialog;
-    int result = dialog.exec();
-    if (result == QDialog::Accepted) {
-        m_dictModel->add(dialog.dictionary());
+    AddDictDialog *dialog = new AddDictDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+    connect(dialog, &QDialog::accepted, this, [this, dialog]() {
+        m_dictModel->add(dialog->dictionary());
         Q_EMIT changed(true);
-    }
+    });
+
+    dialog->open();
 }
 
 void SkkDictWidget::defaultDictClicked() {


### PR DESCRIPTION
https://github.com/fcitx/fcitx5-skk/issues/19
QDialog::exec() was used in SkkDictWidget::addDictClicked(), 
but since this method is deprecated, it has been changed to QDialog::open().