### PR TITLE
replace SKK_DEFAULT_PATH with SKK_PATH

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Build and Install fcitx5-qt
         uses: fcitx/github-actions@cmake
         with:
-          repository: fcitx/fcitx5-qt
           path: fcitx5-qt
           cmake-option: >-
             -DENABLE_QT4=Off -DENABLE_QT5=Off -DENABLE_QT6=On

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 
-set(SKK_PATH "/usr/share/skk/" CACHE STRING "Default path of SKK directory that has SKK-JISYO.L, could start with \$XDG_DATA_DIRS/")
-if("${SKK_DEFAULT_PATH}" MATCHES "SKK-JISYO.L$")
-  message(FATAL_ERROR "SKK_DEFAULT_PATH is superseded by SKK_PATH")
+set(SKK_PATH "/usr/share/skk" CACHE STRING "Default path of SKK directory that contains SKK-JISYO.L, could start with \"\$XDG_DATA_DIRS\"")
+if(NOT ("${SKK_DEFAULT_PATH}" STREQUAL ""))
+    message(FATAL_ERROR "SKK_DEFAULT_PATH option is removed and replaced with SKK_PATH, they have different meaning (file vs directory). Please adjust the config option accordingly.")
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")
 
-set(SKK_DEFAULT_PATH "/usr/share/skk/SKK-JISYO.L" CACHE STRING "Default path of SKK")
+set(SKK_PATH "/usr/share/skk/" CACHE STRING "Default path of SKK directory that has SKK-JISYO.L, could start with \$XDG_DATA_DIRS/")
+if("${SKK_DEFAULT_PATH}" MATCHES "SKK-JISYO.L$")
+  message(FATAL_ERROR "SKK_DEFAULT_PATH is superseded by SKK_PATH")
+endif()
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Please install this packages before build this Program.
  - extra-cmake-modules
  - gettext
 
-You can specify the skk dictionary path by -DSKK_DEFAULT_PATH=path_you_want
+You can specify the skk dictionary path by -DSKK_PATH=path_you_want
 
-By default it's /usr/share/skk/SKK-JISYO.L
+By default it's /usr/share/skk/
 
 ## Installation 
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,6 +1,6 @@
 #ifndef ___CONFIG_H___
 #define ___CONFIG_H___
 
-#define SKK_DEFAULT_PATH "@SKK_DEFAULT_PATH@"
+#define SKK_PATH "@SKK_PATH@"
 
 #endif /* __CONFIG_H__ */

--- a/gui/adddictdialog.cpp
+++ b/gui/adddictdialog.cpp
@@ -111,7 +111,7 @@ void AddDictDialog::browseClicked() {
     if (m_ui->typeComboBox->currentIndex() == DictType_System) {
         QString dir;
         if (path.isEmpty()) {
-            path = SKK_DEFAULT_PATH;
+            path = SKK_PATH "SKK-JISYO.L";
         }
         QFileInfo info(path);
         path = QFileDialog::getOpenFileName(this, _("Select Dictionary File"),

--- a/src/dictionary_list.in
+++ b/src/dictionary_list.in
@@ -1,2 +1,2 @@
 type=file,file=$FCITX_CONFIG_DIR/skk/user.dict,mode=readwrite
-type=file,file=@SKK_PATH@SKK-JISYO.L,mode=readonly
+type=file,file=@SKK_PATH@/SKK-JISYO.L,mode=readonly

--- a/src/dictionary_list.in
+++ b/src/dictionary_list.in
@@ -1,2 +1,2 @@
 type=file,file=$FCITX_CONFIG_DIR/skk/user.dict,mode=readwrite
-type=file,file=@SKK_DEFAULT_PATH@,mode=readonly
+type=file,file=@SKK_PATH@SKK-JISYO.L,mode=readonly


### PR DESCRIPTION
Unify the behavior with https://github.com/fcitx/fcitx5-kkc/commit/8da42fb5ffff3ae1b152eaa7bc4b98f283d4dc03
The benefit is more dictionaries could be added at build time.
This is a breaking change for downstream packagers that explicit set `SKK_DEFAULT_PATH`.