### PR TITLE
Avoid excessive (visual) clearing of preedit

### DIFF
--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -733,12 +733,10 @@ void SkkState::updateUI() {
 
     if (auto str = UniqueCPtr<char, g_free>{skk_context_poll_output(context)}) {
         if (str && str.get()[0]) {
-            // Skk doesn't clear preedit after poll output, do this on our own.
-            preedit_ = Text();
             ic_->commitString(str.get());
         }
     }
-    Text preedit = preedit_;
+    Text preedit = skkContextGetPreedit(context);
 
     // Skk almost filter every key, which makes it calls updateUI on release.
     // We add an additional check here for checking if the UI is empty or not.


### PR DESCRIPTION
# Summary

In some cases preedit should be kept non-empty even after some content is committed. Libskk seems to correctly update the preedit, so stop clearing the preedit (visually) on our own to fix the issue.

# Examples

For example, `a t t` should produce commited=`あっ` and preedit=`t`, but the current implementation only shows `あっ` with no preedit because the second input `t` commits `っ`.

| last processed key | committed text | EXPECTED preedit | ACTUAL preedit | remaining input |
|:--|:--|:--|:--|:--|
| | | | | a t t a |
| a | あ | | | t t a |
| t | あ | t | t | t a |
| t | あっ | t | | a |
| a | あった | | | |

Another example is, when the rule contains custom rom-kana mapping `"tch": ["ch", "っ"]`, then the key sequence `w i t c h i` is expected to cause the following state transitions:

| last processed key | committed text | preedit | remaining input |
|:--|:--|:--|:--|
| | | | w i t c h i |
| w | | w | i t c h i |
| i | うぃ | | t c h i |
| t | うぃ | t | c h i |
| c | うぃ | t c | h i |
| h | うぃっ | c h | i |
| i | うぃっち | | |

However, without this pull request, fcitx5-skk clears the preedit whenever a text is commited, so we get unexpected state transition:

| last processed key | committed text | preedit | remaining input | note |
|:--|:--|:--|:--|:--|
| | | | w i t c h i | |
| w | | w | i t c h i | |
| i | うぃ | | t c h i | commited → preedit is cleared |
| t | うぃ | t | c h i | |
| c | うぃ | t c | h i | |
| h | うぃっ | | i | **should be fixed**: commited → preedit is (visually) cleared |
| i | うぃっち | | | preedit looked empty, but it had "hidden" content `ch`, so `i` constructs `chi` → `ち` |
