### PR TITLE
Add libgee to target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(PkgConfig REQUIRED)
 find_package(Fcitx5Core ${REQUIRED_FCITX_VERSION} REQUIRED)
 find_package(Gettext REQUIRED)
 pkg_check_modules(GObject2 IMPORTED_TARGET "gobject-2.0" REQUIRED)
+pkg_check_modules(Gee IMPORTED_TARGET "gee-0.8" REQUIRED)
 find_package(LibSKK REQUIRED)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(skk
     Fcitx5::Core
     Fcitx5::Config
     PkgConfig::GObject2
+    PkgConfig::Gee
     LibSKK::LibSKK
 )
 set_target_properties(skk PROPERTIES PREFIX "")


### PR DESCRIPTION
Disclaimer: I'm not an expert of CMake, and unsure if this is the correct fix.

Hi, thank you for maintaining the crucial input method engine!
I noticed that I can't build the latest version of `fcitx5-skk` with the latest version of `libskk` in NixOS. More specifically, when I tried building it, `libskk.h` unable to find `gee.h`.

```
error: Cannot build '/nix/store/nwf4aajf7pzsd7z8kg2mq9jpnrpda49h-fcitx5-skk-5.1.8.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/wm3v91wnh9cn42w03bib97nvvjgsfj4i-fcitx5-skk-5.1.8
       Last 25 log lines:
       > [ 29%] Generating skk.conf
       > [ 35%] Generating fcitx5-skk-ko.mo
       > [ 47%] Generating skk-addon.conf
       > [ 52%] Generating fcitx5-skk-fr.mo
       > [ 52%] Generating fcitx5-skk-de.mo
       > [ 70%] Generating fcitx5-skk-he.mo
       > [ 70%] Generating fcitx5-skk-tr.mo
       > [ 70%] Generating fcitx5-skk-zh_CN.mo
       > [ 82%] Generating fcitx5-skk-ru.mo
       > [ 82%] Generating fcitx5-skk-ja.mo
       > [ 88%] Generating fcitx5-skk-zh_TW.mo
       > [ 94%] Generating fcitx5-skk-vi.mo
       > [ 94%] Built target fcitx5-skk-translation
       > [ 94%] Built target org.fcitx.Fcitx5.Addon.Skk.metainfo.xml.in-fmt
       > [ 94%] Built target skk-addon.conf.in-fmt
       > [ 94%] Built target skk.conf.in-fmt
       > In file included from /build/fcitx5-skk/src/skk.h:37,
       >                  from /build/fcitx5-skk/src/skk.cpp:7:
       > /nix/store/l413c83fc11laycx0fa7q75kjdz947hc-libskk-1.0.5/include/libskk/libskk.h:10:10: fatal error: gee.h: No such file or directory
       >    10 | #include <gee.h>
       >       |          ^~~~~~~
       > compilation terminated.
       > make[2]: *** [src/CMakeFiles/skk.dir/build.make:79: src/CMakeFiles/skk.dir/skk.cpp.o] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:351: src/CMakeFiles/skk.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run:
         nix log /nix/store/nwf4aajf7pzsd7z8kg2mq9jpnrpda49h-fcitx5-skk-5.1.8.drv
error: Cannot build '/nix/store/wfykkys86nfqfms22ispr0j844167pyl-default-package.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7ns19nvdmzw8vq71fq60bwsx9ay32844-default-package
```

This patch includes `libgee` to `target_link_libraries`, which resolved the issue for me.


Test setup:
- create a git repository, add `libskk` and `fcitx5-skk` as git submodules, both pointing the latest master branch.
- create following `flake.nix` file, and run `nix build`
```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
    flake-parts.url = "github:hercules-ci/flake-parts";
    self.submodules = true;
  };
  outputs =
    inputs:
    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
      systems = [ "x86_64-linux" ];
      perSystem =
        { system, pkgs, ... }:
        {
          _module.args.pkgs = import inputs.nixpkgs {
            inherit system;
            overlays = [
              (final: prev: {
                libskk = prev.libskk.overrideAttrs (old: {
                  src = ./libskk;
                  # nixpkgs uses (the latest release but) an older version of libskk with a patch from a MR.
                  # since the MR is already merged, we can empty the patch list here for the latest master branch.
                  patches = [ ];
                });
                fcitx5-skk = prev.fcitx5-skk.overrideAttrs (old: {
                  src = ./fcitx5-skk;
                  # nixpkgs still use -DSKK_DEFAULT_PATH.
                  cmakeFlags = [
                    (builtins.elemAt old.cmakeFlags 0)
                    "-DSKK_PATH=${prev.skkDictionaries.l}/share/skk/"
                  ];
                });
              })
            ];
            config = { };
          };
          packages.default = pkgs.fcitx5-skk;
        };
    };
}
```