### PR TITLE
Add clipboard support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(FeatureSummary)
 
 find_package(PkgConfig REQUIRED)
 find_package(Fcitx5Core ${REQUIRED_FCITX_VERSION} REQUIRED)
+find_package(Fcitx5ModuleClipboard REQUIRED)
 find_package(Gettext REQUIRED)
 find_package(LibSKK 1.1.0 REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(SKK_SOURCES
     skk.cpp
+    utils.cpp
 )
 add_fcitx5_addon(skk ${SKK_SOURCES})
 target_link_libraries(skk

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_fcitx5_addon(skk ${SKK_SOURCES})
 target_link_libraries(skk
     Fcitx5::Core
     Fcitx5::Config
+    Fcitx5::Module::Clipboard
     LibSKK::LibSKK
 )
 set_target_properties(skk PROPERTIES PREFIX "")

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -50,8 +50,8 @@
 #include <glib-object.h>
 #include <glib.h>
 #include <libskk/libskk.h>
-#include <sys/types.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #define SKK_DEBUG() FCITX_LOGC(::fcitx::skk_logcategory, Debug)
 
@@ -889,7 +889,6 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
                 }
             }
         }
-
 
         if (util::surrounding_get_safe_delta(cursor_pos, anchor_pos,
                                              &relative_selected_length)) {

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  */
+#include "clipboard_public.h"
 #include "skk.h"
+#include "utils.h"
 #include <fcntl.h>
 #include <algorithm>
 #include <array>
@@ -48,6 +50,8 @@
 #include <glib-object.h>
 #include <glib.h>
 #include <libskk/libskk.h>
+#include <sys/types.h>
+#include <stdlib.h>
 
 #define SKK_DEBUG() FCITX_LOGC(::fcitx::skk_logcategory, Debug)
 
@@ -853,11 +857,46 @@ gboolean SkkState::delete_surrounding_text_cb(GObject * /*unused*/, gint offset,
 }
 
 void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
-    SkkContext *context = skk->context();
-    InputContext *ic = skk->ic_;
-    SkkEngine *engine = skk->engine_;
+    auto *context = skk->context();
+    auto *ic = skk->ic_;
+    auto *engine = skk->engine_;
+    auto *clipboard = engine->clipboard();
+    std::string text;
 
-    std::string text = engine->clipboard()->call<IClipboard::clipboard>(ic);
+    if (ic->capabilityFlags().test(fcitx::CapabilityFlag::SurroundingText) &&
+                ic->surroundingText().isValid()) {
+
+        const std::string surrounding_text(ic->surroundingText().text());
+        uint cursor_pos = ic->surroundingText().cursor();
+        uint anchor_pos = ic->surroundingText().anchor();
+        int32_t relative_selected_length = 0;
+
+        if (cursor_pos == anchor_pos) {
+            if (clipboard) {
+                auto primary_text =
+                    clipboard->call<fcitx::IClipboard::primary>(ic);
+                uint new_anchor_pos = 0;
+                if (util::surrounding_get_anchor_pos_from_selection(
+                            surrounding_text, primary_text, cursor_pos,
+                            &new_anchor_pos)) {
+                    anchor_pos = new_anchor_pos;
+                }
+            }
+        }
+
+        if (util::surrounding_get_safe_delta(cursor_pos, anchor_pos,
+                                             &relative_selected_length)) {
+            const uint32_t selection_start = std::min(cursor_pos, anchor_pos);
+            const uint32_t selection_length = abs(relative_selected_length);
+            text = util::utf8_string_substr(surrounding_text,
+                                            selection_start, selection_length);
+        }
+    }
+
+    if (text.empty() && clipboard) {
+            text = clipboard->call<fcitx::IClipboard::clipboard>(ic);
+    }
+
     skk_context_set_selection_text(context, text.c_str());
 }
 

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -617,6 +617,8 @@ SkkState::SkkState(SkkEngine *engine, InputContext *ic)
                      G_CALLBACK(retrieve_surrounding_text_cb), this);
     g_signal_connect(context, "delete_surrounding_text",
                      G_CALLBACK(delete_surrounding_text_cb), this);
+    g_signal_connect(context, "request_selection_text",
+                     G_CALLBACK(request_selection_text_cb), this);
     updateInputMode();
 
     const char *AUTO_START_HENKAN_KEYWORDS[] = {
@@ -849,6 +851,16 @@ gboolean SkkState::delete_surrounding_text_cb(GObject * /*unused*/, gint offset,
     ic->deleteSurroundingText(offset, nchars);
     return true;
 }
+
+void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
+    SkkContext *context = skk->context();
+    InputContext *ic = skk->ic_;
+    SkkEngine *engine = skk->engine_;
+
+    std::string text = engine->clipboard()->call<IClipboard::clipboard>(ic);
+    skk_context_set_selection_text(context, text.c_str());
+}
+
 } // namespace fcitx
 
 FCITX_ADDON_FACTORY_V2(skk, fcitx::SkkAddonFactory)

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -865,22 +865,26 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
 
     if (ic->capabilityFlags().test(fcitx::CapabilityFlag::SurroundingText) &&
                 ic->surroundingText().isValid()) {
-
         std::string surrounding_text(ic->surroundingText().text());
         uint32_t cursor_pos = ic->surroundingText().cursor();
         uint32_t anchor_pos = ic->surroundingText().anchor();
         int32_t relative_selected_length = 0;
-        const uint32_t preedit_length =
-                g_utf8_strlen(skk_context_get_preedit(context), -1);
+        const std::string preedit_text =
+                std::string(skk_context_get_preedit(context));
+        const uint32_t preedit_length = utf8::length(preedit_text);
 
         if (preedit_length) {
             const uint32_t end = utf8::length(surrounding_text);
             const std::string tail = util::utf8_string_substr(surrounding_text,
                                                               cursor_pos, end);
-            cursor_pos -= preedit_length;
-            anchor_pos -= preedit_length;
-            const std::string head = util::utf8_string_substr(surrounding_text,
-                                                              0, cursor_pos);
+            std::string head = util::utf8_string_substr(surrounding_text,
+                                                        0, cursor_pos);
+
+            if (head.ends_with(preedit_text)) {
+                cursor_pos -= preedit_length;
+                anchor_pos -= preedit_length;
+                head = util::utf8_string_substr(head, 0, cursor_pos);
+            }
             surrounding_text = head + tail;
         }
 
@@ -901,13 +905,13 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
                                              &relative_selected_length)) {
             const uint32_t selection_start = std::min(cursor_pos, anchor_pos);
             const uint32_t selection_length = abs(relative_selected_length);
-            text = util::utf8_string_substr(surrounding_text,
-                                            selection_start, selection_length);
+            text = util::utf8_string_substr(surrounding_text, selection_start,
+                                            selection_length);
         }
     }
 
     if (text.empty() && clipboard) {
-            text = clipboard->call<fcitx::IClipboard::clipboard>(ic);
+        text = clipboard->call<fcitx::IClipboard::clipboard>(ic);
     }
 
     skk_context_set_selection_text(context, text.c_str());

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -867,21 +867,28 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
                 ic->surroundingText().isValid()) {
 
         std::string surrounding_text(ic->surroundingText().text());
-        uint cursor_pos = ic->surroundingText().cursor();
-        uint anchor_pos = ic->surroundingText().anchor();
+        uint32_t cursor_pos = ic->surroundingText().cursor();
+        uint32_t anchor_pos = ic->surroundingText().anchor();
         int32_t relative_selected_length = 0;
-        int32_t preedit_length = g_utf8_strlen(skk_context_get_preedit(context), -1);
+        const uint32_t preedit_length =
+                g_utf8_strlen(skk_context_get_preedit(context), -1);
 
         if (preedit_length) {
+            const uint32_t end = utf8::length(surrounding_text);
+            const std::string tail = util::utf8_string_substr(surrounding_text,
+                                                              cursor_pos, end);
             cursor_pos -= preedit_length;
             anchor_pos -= preedit_length;
-            surrounding_text.erase(preedit_length);
+            const std::string head = util::utf8_string_substr(surrounding_text,
+                                                              0, cursor_pos);
+            surrounding_text = head + tail;
         }
+
         if (cursor_pos == anchor_pos) {
             if (clipboard) {
-                auto primary_text =
-                    clipboard->call<fcitx::IClipboard::primary>(ic);
-                uint new_anchor_pos = 0;
+                std::string primary_text =
+                        clipboard->call<fcitx::IClipboard::primary>(ic);
+                uint32_t new_anchor_pos = 0;
                 if (util::surrounding_get_anchor_pos_from_selection(
                             surrounding_text, primary_text, cursor_pos,
                             &new_anchor_pos)) {

--- a/src/skk.cpp
+++ b/src/skk.cpp
@@ -866,11 +866,17 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
     if (ic->capabilityFlags().test(fcitx::CapabilityFlag::SurroundingText) &&
                 ic->surroundingText().isValid()) {
 
-        const std::string surrounding_text(ic->surroundingText().text());
+        std::string surrounding_text(ic->surroundingText().text());
         uint cursor_pos = ic->surroundingText().cursor();
         uint anchor_pos = ic->surroundingText().anchor();
         int32_t relative_selected_length = 0;
+        int32_t preedit_length = g_utf8_strlen(skk_context_get_preedit(context), -1);
 
+        if (preedit_length) {
+            cursor_pos -= preedit_length;
+            anchor_pos -= preedit_length;
+            surrounding_text.erase(preedit_length);
+        }
         if (cursor_pos == anchor_pos) {
             if (clipboard) {
                 auto primary_text =
@@ -883,6 +889,7 @@ void SkkState::request_selection_text_cb(GObject * /*unused*/, SkkState *skk) {
                 }
             }
         }
+
 
         if (util::surrounding_get_safe_delta(cursor_pos, anchor_pos,
                                              &relative_selected_length)) {

--- a/src/skk.h
+++ b/src/skk.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <clipboard_public.h>
 #include <fcitx-config/configuration.h>
 #include <fcitx-config/enum.h>
 #include <fcitx-config/iniparser.h>
@@ -177,6 +178,8 @@ public:
     auto modeAction() { return modeAction_.get(); }
     auto userRule() { return userRule_.get(); }
 
+    FCITX_ADDON_DEPENDENCY_LOADER(clipboard, instance_->addonManager());
+
 private:
     void loadRule();
     void loadDictionary();
@@ -229,6 +232,7 @@ private:
                                                  SkkState *skk);
     static gboolean delete_surrounding_text_cb(GObject *, gint offset,
                                                guint nchars, SkkState *skk);
+    static void request_selection_text_cb(GObject *, SkkState *skk);
 
     SkkEngine *engine_;
     InputContext *ic_;

--- a/src/skk.h
+++ b/src/skk.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <clipboard_public.h>
 #include <fcitx-config/configuration.h>
 #include <fcitx-config/enum.h>
 #include <fcitx-config/iniparser.h>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,115 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ *  SPDX-FileCopyrightText: 2005 Takuro Ashie
+ *  SPDX-FileCopyrightText: 2012 CSSlayer <wengxt@gmail.com>
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "utils.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <fcitx-utils/utf8.h>
+#include <limits>
+#include <string>
+#include <sys/types.h>
+
+std::string util::utf8_string_substr(const std::string &s, size_t start,
+                                     size_t len) {
+    auto iter = fcitx::utf8::nextNChar(s.begin(), start);
+    auto end = fcitx::utf8::nextNChar(iter, len);
+    std::string result(iter, end);
+    return result;
+}
+
+bool util::surrounding_get_safe_delta(uint from, uint to, int32_t *delta) {
+    const int64_t kInt32AbsMax =
+        std::llabs(static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+    const int64_t kInt32AbsMin =
+        std::llabs(static_cast<int64_t>(std::numeric_limits<int32_t>::min()));
+    const int64_t kInt32SafeAbsMax = std::min(kInt32AbsMax, kInt32AbsMin);
+
+    const int64_t diff = static_cast<int64_t>(from) - static_cast<int64_t>(to);
+    if (std::llabs(diff) > kInt32SafeAbsMax) {
+        return false;
+    }
+
+    *delta = static_cast<int32_t>(diff);
+    return true;
+}
+
+// Returns true if |surrounding_text| contains |selected_text|
+// from |cursor_pos| to |*anchor_pos|.
+// Otherwise returns false.
+static bool search_anchor_pos_forward(const std::string &surrounding_text,
+                                      const std::string &selected_text,
+                                      size_t selected_chars_len,
+                                      uint cursor_pos, uint *anchor_pos) {
+
+    size_t len = fcitx::utf8::length(surrounding_text);
+    if (len < cursor_pos) {
+        return false;
+    }
+
+    size_t offset =
+        fcitx::utf8::ncharByteLength(surrounding_text.begin(), cursor_pos);
+
+    if (surrounding_text.compare(offset, selected_text.size(), selected_text) !=
+        0) {
+        return false;
+    }
+    *anchor_pos = cursor_pos + selected_chars_len;
+    return true;
+}
+
+// Returns true if |surrounding_text| contains |selected_text|
+// from |*anchor_pos| to |cursor_pos|.
+// Otherwise returns false.
+bool search_anchor_pos_backward(const std::string &surrounding_text,
+                                const std::string &selected_text,
+                                size_t selected_chars_len, uint cursor_pos,
+                                uint *anchor_pos) {
+    if (cursor_pos < selected_chars_len) {
+        return false;
+    }
+
+    // Skip |iter| to (potential) anchor pos.
+    const uint skip_count = cursor_pos - selected_chars_len;
+    if (skip_count > cursor_pos) {
+        return false;
+    }
+    size_t offset =
+        fcitx::utf8::ncharByteLength(surrounding_text.begin(), skip_count);
+
+    if (surrounding_text.compare(offset, selected_text.size(), selected_text) !=
+        0) {
+        return false;
+    }
+    *anchor_pos = skip_count;
+    return true;
+}
+
+bool util::surrounding_get_anchor_pos_from_selection(
+    const std::string &surrounding_text, const std::string &selected_text,
+    uint cursor_pos, uint *anchor_pos) {
+    if (surrounding_text.empty()) {
+        return false;
+    }
+
+    if (selected_text.empty()) {
+        return false;
+    }
+
+    const size_t selected_chars_len = fcitx::utf8::length(selected_text);
+
+    if (search_anchor_pos_forward(surrounding_text, selected_text,
+                                  selected_chars_len, cursor_pos, anchor_pos)) {
+        return true;
+    }
+
+    return search_anchor_pos_backward(surrounding_text, selected_text,
+                                      selected_chars_len, cursor_pos,
+                                      anchor_pos);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2005 Takuro Ashie
+ * SPDX-FileCopyrightText: 2017-2017 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ */
+#ifndef _FCITX5_SKK_UTILS_H_
+#define _FCITX5_SKK_UTILS_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <fcitx-utils/charutils.h>
+#include <fcitx-utils/key.h>
+#include <fcitx/event.h>
+#include <string>
+#include <string_view>
+
+namespace util {
+
+std::string utf8_string_substr(const std::string &s, size_t start, size_t len);
+
+bool match_key_event(const fcitx::KeyList &list, const fcitx::Key &key,
+                     fcitx::KeyStates ignore_mask = fcitx::KeyStates());
+std::string convert_to_wide(std::string_view str);
+std::string convert_to_half(const std::string &str);
+std::string convert_to_katakana(const std::string &hira, bool half = false);
+
+bool key_is_keypad(const fcitx::Key &key);
+std::string keypad_to_string(const fcitx::KeyEvent &key);
+void launch_program(std::string_view command);
+
+bool surrounding_get_safe_delta(unsigned int from, unsigned int to,
+                                int32_t *delta);
+
+bool surrounding_get_anchor_pos_from_selection(
+    const std::string &surrounding_text, const std::string &selected_text,
+    unsigned int cursor_pos, unsigned int *anchor_pos);
+
+inline char get_ascii_code(const fcitx::Key &key) {
+    auto chr = fcitx::Key::keySymToUnicode(key.sym());
+    if (fcitx::charutils::isprint(chr)) {
+        return chr;
+    }
+    return 0;
+}
+
+inline char get_ascii_code(const fcitx::KeyEvent &event) {
+    return get_ascii_code(event.rawKey());
+}
+
+const fcitx::KeyList &selection_keys();
+} // namespace util
+
+#endif // _FCITX5_SKK_UTILS_H_


### PR DESCRIPTION
This change wires up libskk's clipboard support to fcitx5-skk via the fcitx5 clipboard module. This allows entries to be registered from clipboard contents, which is useful when adding words or emojis to the user dictionary.

Usage:  
Add the `register` command in the libskk keymap.  
  
Tested on:  
- fcitx5 5.1.19  
- fcitx5-skk 5.1.10  
- libskk 1.1.1